### PR TITLE
#1 イシューテンプレの作成

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,148 @@
+name: Bug
+description: 不具合の報告から原因調査、対応内容まで記録する
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        不具合の内容を記載してください。原因調査や対応方針が判明している場合はあわせて記載してください。
+
+  - type: textarea
+    id: issue-summary
+    attributes:
+      label: 事象
+      description: 発生している問題を簡潔に記載してください。
+      placeholder: 例: 保存ボタンを押しても変更内容が反映されない
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      description: 業務影響に応じて選択してください。Critical は業務停止または全ユーザー影響、High は主要機能停止または 50%以上のユーザー影響、Medium は回避策ありの一部機能影響、Low は限定的な影響です。
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact-scope
+    attributes:
+      label: 影響範囲
+      description: どのユーザー、機能、画面、運用に影響するかを記載してください。
+      placeholder: |
+        例:
+        - 管理者ユーザーのみ影響
+        - CSV 取込機能全体に影響
+        - 月次運用作業が継続できない
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: 再現手順
+      description: 対象画面、入力値、操作順、実行回数を含めて、第三者が同じ条件で再現できるように記載してください。
+      placeholder: |
+        1. 設定画面を開く
+        2. 表示名に「テスト太郎」を入力する
+        3. 保存ボタンを1回押す
+        4. 一覧画面へ戻る
+        5. 表示名が更新されていないことを確認する
+    validations:
+      required: true
+
+  - type: textarea
+    id: occurrence-conditions
+    attributes:
+      label: 発生条件
+      description: 発生する条件、対象ユーザー、入力値、事前状態、発生頻度を記載してください。
+      placeholder: |
+        例:
+        - ログイン済みユーザーで発生
+        - 特定のCSVファイルをアップロードした場合に発生
+        - 毎回発生 / ときどき発生
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 期待される動作
+      description: 本来どう動くべきかを、画面表示、メッセージ、データ更新結果を含めて記載してください。
+      placeholder: 例: 保存完了メッセージが表示され、一覧画面に変更内容が反映される
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: 実際の動作
+      description: 実際に発生した結果を、表示メッセージ、挙動、データ状態を含めて記載してください。
+      placeholder: 例: 保存完了メッセージは表示されるが、一覧画面に変更内容が反映されない
+    validations:
+      required: true
+
+  - type: textarea
+    id: investigation
+    attributes:
+      label: 原因調査
+      description: 調査して分かったこと、確認した範囲、原因候補があれば記載してください。
+      placeholder: |
+        例:
+        - 〇〇の設定値が未反映だった
+        - △△の条件分岐で想定外の値が入っていた
+        - ログと再現確認の結果、原因は ×× と判断した
+
+  - type: textarea
+    id: resolution
+    attributes:
+      label: 対応内容
+      description: 修正方針、回避策、恒久対応案が決まっていれば記載してください。
+      placeholder: |
+        例:
+        - 入力条件の取り扱いを見直す
+        - 対象処理の分岐条件を修正する
+        - 暫定回避策を案内し、恒久対応は別途実施する
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: 暫定回避策
+      description: 利用者向けの暫定回避策があれば記載してください。
+      placeholder: 例: 一度再読み込みすると処理を継続できる
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 確認内容・未確認事項
+      description: 修正後に確認した観点、確認結果、未確認事項を記載してください。
+      placeholder: |
+        例:
+        - 再現手順で不具合が発生しないことを確認
+        - 関連機能A、Bに影響がないことを確認
+        - 本番環境での確認は未実施
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境情報
+      description: OS、ブラウザ、アプリ版、対象ブランチ、発生環境を記載してください。不明な場合は「不明」と記載してください。
+      placeholder: 例: Windows 11 / Chrome 134 / main / 開発環境
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 証跡
+      description: ログ、スクリーンショット、エラーメッセージ、関連URLなどがあれば記載してください。個人情報、認証情報、機密情報は必ずマスクしてください。
+      placeholder: |
+        例:
+        - エラーメッセージ: 500 Internal Server Error
+        - ログ: save() 実行時に NullReferenceException
+        - URL: /settings/profile

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,76 @@
+name: Feature
+description: 新機能追加や利用者価値を高める機能改善を提案する
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        実現したい機能や改善内容を整理して記載してください。
+
+  - type: textarea
+    id: overview
+    attributes:
+      label: 概要
+      description: 何を実現したいかを簡潔に記載してください。
+      placeholder: 例: Issue テンプレートを導入し、記載内容を標準化する
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・目的
+      description: なぜ必要なのか、どの課題を解決したいのか、期待する効果や目標値を記載してください。
+      placeholder: 現状の課題、期待する効果、利用シーン、改善したい指標（例: 作業時間を30%短縮）など
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 対象範囲
+      description: どの機能、利用者、運用に影響するかを記載してください。
+      placeholder: 例: Issue 作成フロー全体、開発メンバー全員が対象
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: 対象外
+      description: 今回の対応に含めない内容を記載してください。対象外がない場合は「なし」と記載してください。
+      placeholder: 例: PR テンプレートの整備は今回の対象外
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 完了条件
+      description: 完了と判断できる条件を、第三者が確認できる具体的な条件でチェックリスト形式にしてください。
+      placeholder: |
+        - [ ] 対象機能を想定手順で利用できる
+        - [ ] 必須未入力時に保存できない
+        - [ ] 関連機能に回帰不具合がない
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 確認方法
+      description: 実装後にどのように確認するかを、確認観点、確認手順、期待結果を含めて記載してください。
+      placeholder: |
+        例:
+        - 対象機能が利用できることを確認する
+        - 異常入力時に想定どおりエラーになることを確認する
+        - 関連機能に影響がないことを確認する
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 補足
+      description: 関連資料、検討メモ、参考リンクなどがあれば記載してください。
+      placeholder: 補足情報があれば記載

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,74 @@
+name: Refactor
+description: 既存実装や構成の改善を提案する
+title: "[Refactor] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        既存の構成や実装の改善案を整理して記載してください。
+
+  - type: textarea
+    id: target
+    attributes:
+      label: 対象
+      description: どのファイル、機能、運用フローを改善対象とするかを記載してください。
+      placeholder: 例: .github/ISSUE_TEMPLATE 配下のテンプレート構成
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-issue
+    attributes:
+      label: 現状の課題
+      description: 何が問題で、なぜ改善が必要かを記載してください。
+      placeholder: 保守性、重複、可読性、運用上の課題など
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 改善方針
+      description: どのように改善したいかを記載してください。
+      placeholder: 例: 共通項目を整理し、テンプレートの粒度をそろえる
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: 対象外
+      description: 今回の改善に含めない内容を記載してください。対象外がない場合は「なし」と記載してください。
+      placeholder: 例: 文言見直しのみ対象とし、運用ルール変更は対象外
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 完了条件
+      description: 改善完了を確認するための条件を、第三者が検証できる具体的な条件で記載してください。
+      placeholder: |
+        - [ ] 重複定義が削除され、定義箇所が一箇所に統一されている
+        - [ ] 既存機能の回帰不具合が発生していない
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: 影響範囲・懸念点
+      description: 影響する範囲や注意点があれば記載してください。
+      placeholder: 関連箇所、移行時の注意点など
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 確認方法
+      description: 改善後にどのように効果や影響を確認するかを記載してください。
+      placeholder: |
+        例:
+        - 重複定義がなくなっていることを確認する
+        - 既存運用で支障が出ないことを確認する
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,81 @@
+name: Task
+description: 定型作業やその他の対応タスクを起票する
+title: "[Task] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        実施するタスクの内容と完了条件を整理して記載してください。
+
+  - type: textarea
+    id: task-summary
+    attributes:
+      label: 内容
+      description: 実施する内容を簡潔に記載してください。
+      placeholder: 例: Issue テンプレートの運用ルールを README に追記する
+    validations:
+      required: true
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 目的
+      description: このタスクを実施する理由や背景を記載してください。
+      placeholder: 目的や期待する効果を記載
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 対象範囲
+      description: 対象となるファイル、機能、関係者、運用範囲を記載してください。
+      placeholder: 例: README と .github 配下の設定ファイルが対象
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: 対象外
+      description: 今回のタスクに含めない内容を記載してください。対象外がない場合は「なし」と記載してください。
+      placeholder: 例: 実装後の周知対応は別タスクで実施
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: 完了条件
+      description: 完了とみなす条件を、第三者が検証できる具体的な条件でチェックリスト形式に記載してください。
+      placeholder: |
+        - [ ] 対象ファイルが更新され、差分が確認できる
+        - [ ] 関連手順どおりに実施して期待結果になる
+    validations:
+      required: true
+
+  - type: input
+    id: related-issue
+    attributes:
+      label: 関連 Issue
+      description: 関連する Issue 番号やリンクがあれば記載してください。
+      placeholder: 例: #1
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: 確認方法
+      description: タスク完了後にどのように確認するかを、確認観点、確認手順、期待結果を含めて記載してください。
+      placeholder: |
+        例:
+        - 対象ファイルが更新されていることを確認する
+        - 期待した運用手順で利用できることを確認する
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 補足
+      description: 補足事項や共有しておきたい情報があれば記載してください。
+      placeholder: 補足情報があれば記載


### PR DESCRIPTION
## 概要
Issue #1 に対応し、GitHub Issue Forms を整備しました。

## 変更内容
- .github/ISSUE_TEMPLATE 配下に Feature / Bug / Refactor / Task の4テンプレートを追加
- blank issue を無効化する config.yml を追加
- 各テンプレートをレビュー指摘に基づき改善

## 確認
- YAML 構文エラーがないことを確認

Closes #1